### PR TITLE
Improve stability

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Keyboard
 ========
 
-[![Build Status](https://travis-ci.org/creasty/Keyboard.svg?branch=master)](https://travis-ci.org/creasty/Keyboard)
+[![Build Status](https://travis-ci.com/creasty/Keyboard.svg?branch=master)](https://travis-ci.com/creasty/Keyboard)
 [![GitHub release](https://img.shields.io/github/release/creasty/Keyboard.svg)](https://github.com/creasty/Keyboard/releases)
 [![License](https://img.shields.io/github/license/creasty/Keyboard.svg)](./LICENSE)
 

--- a/keyboard/Core/Emitter.swift
+++ b/keyboard/Core/Emitter.swift
@@ -1,15 +1,15 @@
 import Cocoa
 
 protocol EmitterType {
+    func setProxy(_ proxy: CGEventTapProxy?)
     func emit(code: KeyCode)
     func emit(code: KeyCode, flags: CGEventFlags)
     func emit(code: KeyCode, action: Emitter.Action)
     func emit(code: KeyCode, flags: CGEventFlags, action: Emitter.Action)
 }
 
-struct Emitter: EmitterType {
+class Emitter: EmitterType {
     struct Const {
-        static let noremapFlag: CGEventFlags = .maskAlphaShift
         static let pauseInterval: UInt32 = 1000
     }
 
@@ -30,12 +30,10 @@ struct Emitter: EmitterType {
         }
     }
 
-    static func checkAndRemoveNoremapFlag(cgEvent: CGEvent) -> Bool {
-        if cgEvent.flags.contains(Const.noremapFlag) {
-            cgEvent.flags.remove(Const.noremapFlag)
-            return true
-        }
-        return false
+    private var proxy: CGEventTapProxy?
+
+    func setProxy(_ proxy: CGEventTapProxy?) {
+        self.proxy = proxy
     }
 
     func emit(code: KeyCode) {
@@ -61,8 +59,9 @@ struct Emitter: EmitterType {
                 virtualKey: code.rawValue,
                 keyDown: $0
             )
-            e?.flags = flags.union(Const.noremapFlag)
-            e?.post(tap: .cghidEventTap)
+            e?.flags = flags
+            e?.tapPostEvent(proxy)
         }
     }
 }
+

--- a/keyboard/Core/EventManager.swift
+++ b/keyboard/Core/EventManager.swift
@@ -2,7 +2,7 @@ import Cocoa
 
 protocol EventManagerType {
     func register(handler: Handler)
-    func handle(cgEvent: CGEvent) -> Unmanaged<CGEvent>?
+    func handle(proxy: CGEventTapProxy, cgEvent: CGEvent) -> Unmanaged<CGEvent>?
 }
 
 final class EventManager: EventManagerType {
@@ -25,10 +25,9 @@ final class EventManager: EventManagerType {
         }
     }
 
-    func handle(cgEvent: CGEvent) -> Unmanaged<CGEvent>? {
-        guard !Emitter.checkAndRemoveNoremapFlag(cgEvent: cgEvent) else {
-            return Unmanaged.passRetained(cgEvent)
-        }
+    func handle(proxy: CGEventTapProxy, cgEvent: CGEvent) -> Unmanaged<CGEvent>? {
+        emitter.setProxy(proxy)
+
         guard let event = NSEvent(cgEvent: cgEvent) else {
             return Unmanaged.passRetained(cgEvent)
         }

--- a/keyboard/Handlers/AppSwitchHandler.swift
+++ b/keyboard/Handlers/AppSwitchHandler.swift
@@ -36,11 +36,9 @@ extension ApplicationLaunchable {
 //
 final class AppSwitchHandler: Handler, ApplicationLaunchable {
     let workspace: NSWorkspace
-    private let emitter: EmitterType
 
-    init(workspace: NSWorkspace, emitter: EmitterType) {
+    init(workspace: NSWorkspace) {
         self.workspace = workspace
-        self.emitter = emitter
     }
 
     func activateSuperKeys() -> [KeyCode] {

--- a/keyboard/Handlers/InputSourceHandler.swift
+++ b/keyboard/Handlers/InputSourceHandler.swift
@@ -6,12 +6,9 @@ import InputMethodKit
 //     Ctrl-; Select next source in the input menu
 //
 final class InputSourceHandler: Handler {
-    private let emitter: EmitterType
     private let inputSources: [TISInputSource]
 
-    init(emitter: EmitterType) {
-        self.emitter = emitter
-
+    init() {
         let inputSourceNSArray = TISCreateInputSourceList(nil, false).takeRetainedValue() as NSArray
         let inputSourceList = inputSourceNSArray as! [TISInputSource]
         self.inputSources = inputSourceList.filter { $0.isKeyboardInputSource && $0.isSelectable }


### PR DESCRIPTION
## Why & What

- Re-enable event tap after a timeout. — No more occasional manual restarts
- Use `tapPostEvent` in `Emitter` and remove `noremapFlag` bullshits; Apparently, that's the proper way to do it.