### PR TITLE
Fix for Monterey

### DIFF
--- a/keyboard/Handlers/NavigationHandler.swift
+++ b/keyboard/Handlers/NavigationHandler.swift
@@ -83,14 +83,14 @@ final class NavigationHandler: Handler, ApplicationLaunchable {
             if hasWitch {
                 emitter.emit(keyCode: .tab, flags: [.maskControl, .maskAlternate], action: .both)
             } else {
-                emitter.emit(keyCode: .f1, flags: [.maskCommand], action: .both)
+                emitter.emit(keyCode: .f1, flags: [.maskCommand, .maskSecondaryFn], action: .both)
             }
             return true
-        case [.b], [.p]:
+        case [.b]:
             if hasWitch {
                 emitter.emit(keyCode: .tab, flags: [.maskControl, .maskAlternate, .maskShift], action: .both)
             } else {
-                emitter.emit(keyCode: .f1, flags: [.maskCommand, .maskShift], action: .both)
+                emitter.emit(keyCode: .f1, flags: [.maskCommand, .maskShift, .maskSecondaryFn], action: .both)
             }
             return true
         case [.m]:


### PR DESCRIPTION
## Why

`KeyCode.f1` no longer acts as a standard function key in Monterey.

<img width="668" alt="Screen Shot 2021-12-03 at 21 26 41" src="https://user-images.githubusercontent.com/1695538/144602423-0e25701a-61f3-4b76-ac32-b86a7180fcc6.png">

P.S. In Big Sur, `KeyCode.f1` always served as a standard function key regardless of the system preference.